### PR TITLE
Removendo construtor de teste de CardBattle

### DIFF
--- a/src/cardbattle/CardBattle.java
+++ b/src/cardbattle/CardBattle.java
@@ -7,18 +7,9 @@ public class CardBattle {
 	private Character[] ch = new Character[2];
 	private SkillEvaluator skillEvaluator = new SkillEvaluator();
 
-	/**
-	 * Apenas para testes sem personagens.
-	 */
-	public CardBattle() {
+	public CardBattle(Character... characters) {
 		for (int i = 0; i < 2; i++) {
-			ch[i] = new Character();
-		}
-	}
-
-	public CardBattle(CharacterTemplate... characters) {
-		for (int i = 0; i < 2; i++) {
-			ch[i] = new Character(characters[i]);
+			ch[i] = characters[i];
 		}
 	}
 

--- a/test/cardbattle/CardBattleTest.java
+++ b/test/cardbattle/CardBattleTest.java
@@ -25,7 +25,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testSkill() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, ATTACK_QUICK);
 		b.endTurn();
 		assertThat(b.hp(2), is(25));
@@ -34,7 +34,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testSkill2() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(2, ATTACK);
 		b.endTurn();
 		assertThat(b.hp(1), is(20));
@@ -43,7 +43,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testBattleOver() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(2, ATTACK_QUICK);
 		b.endTurn();
 		b.setSkill(2, ATTACK);
@@ -55,7 +55,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testBattleOver2() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, ATTACK_SLOW);
 		b.endTurn();
 		b.setSkill(1, ATTACK_SLOW);
@@ -65,7 +65,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testBattleDraw() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(2, ATTACK_SLOW);
 		b.setSkill(1, ATTACK_SLOW);
 		b.endTurn();
@@ -77,7 +77,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testBattleSkillSpeed1() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, ATTACK_QUICK);
 		b.setSkill(2, ATTACK);
 		b.endTurn();
@@ -88,7 +88,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testBattleSkillSpeed2() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, ATTACK_SLOW);
 		b.setSkill(2, ATTACK);
 		b.endTurn();
@@ -99,13 +99,13 @@ public class CardBattleTest {
 
 	@Test
 	public void testBattleNotOver() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		assertThat(b.winner(), nullValue());
 	}
 	
 //	@Test
 	public void testProjectile2Vs1() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, ATTACK);
 //		b.setSkill(2, SKILL_FIREBALL);
 		b.endTurn();
@@ -116,7 +116,7 @@ public class CardBattleTest {
 
 //	@Test
 	public void testProjectile1Vs2() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(2, ATTACK);
 //		b.setSkill(1, SKILL_FIREBALL);
 		b.endTurn();
@@ -127,7 +127,7 @@ public class CardBattleTest {
 
 //	@Test
 	public void testProjectile3() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(2, ATTACK_QUICK);
 //		b.setSkill(1, SKILL_FIREBALL);
 		b.endTurn();
@@ -138,7 +138,7 @@ public class CardBattleTest {
 
 //	@Test
 	public void testProjectiles() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 //		b.setSkill(2, SKILL_FIREBALL);
 //		b.setSkill(1, SKILL_FIREBALL);
 		b.endTurn();
@@ -149,7 +149,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testSlashSlash() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, SLASH);
 		b.setSkill(2, ATTACK);
 		b.endTurn();
@@ -165,7 +165,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testSlashHeavySlash() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, SLASH);
 		b.endTurn();
 		assertThat(b.hp(1), is(30));
@@ -180,7 +180,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testHeavySlashKnockdownDraw() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, HEAVY_SLASH);
 		b.endTurn();
 		b.setSkill(1, HEAVY_SLASH);
@@ -193,7 +193,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testHeavySlashKnockdownWin() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, HEAVY_SLASH);
 		b.endTurn();
 		b.setSkill(1, HEAVY_SLASH);
@@ -206,7 +206,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testHeavySlashVsHeavySlash() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, HEAVY_SLASH);
 		b.setSkill(2, HEAVY_SLASH);
 		b.endTurn();
@@ -222,7 +222,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testHeavySlashUnsuccessfull() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, HEAVY_SLASH);
 		b.setSkill(2, ATTACK_QUICK);
 		b.endTurn();
@@ -238,7 +238,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testSlashUnsuccessfull() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, SLASH);
 		b.setSkill(2, ATTACK_QUICK);
 		b.endTurn();
@@ -253,7 +253,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testSlashTripleSlash() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, SLASH);
 		b.setSkill(2, ATTACK_SLOW);
 		b.endTurn();
@@ -268,7 +268,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testMeteorSlash() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, METEOR);
 		b.setSkill(2, SLASH);
 		b.endTurn();
@@ -278,7 +278,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testMeteorHeavySlash() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, METEOR);
 		b.setSkill(2, HEAVY_SLASH);
 		b.endTurn();
@@ -288,7 +288,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testMeteorQuickAttack() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, METEOR);
 		b.setSkill(2, ATTACK_QUICK);
 		b.endTurn();
@@ -298,7 +298,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testMeteorAttackDSpeed() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, METEOR);
 		b.setSkill(2, ATTACK_D_SPEED);
 		b.endTurn();
@@ -308,7 +308,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testMeteorAttackESpeed() {
-		CardBattle b = new CardBattle();
+		CardBattle b = new CardBattle(new Character(), new Character());
 		b.setSkill(1, METEOR);
 		b.setSkill(2, ATTACK_E_SPEED);
 		b.endTurn();
@@ -318,7 +318,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testCharacterSkillsValid() {
-		CardBattle b = new CardBattle(LASH, AYLLAN);
+		CardBattle b = new CardBattle(new Character(LASH), new Character(AYLLAN));
 		b.setSkill(1, SLASH);
 		b.setSkill(2, MIND_BLAST);
 		b.endTurn();
@@ -328,7 +328,7 @@ public class CardBattleTest {
 
 	@Test
 	public void testCharacterSkillsInvalid() {
-		CardBattle b = new CardBattle(LASH, AYLLAN);
+		CardBattle b = new CardBattle(new Character(LASH), new Character(AYLLAN));
 		try {
 			b.setSkill(1, SLASH);
 			org.junit.Assert.fail("Expected InvalidSkillException");


### PR DESCRIPTION
Assim remove o construtor de teste do CardBattle.
No entanto fica um pouco mais verboso, não dá pra usar CharacterTemplate no construtor a menos que seja criado um template do personagem genérico.
